### PR TITLE
wait: race to resolve or reject

### DIFF
--- a/wait-to-resolve-reject/index.ts
+++ b/wait-to-resolve-reject/index.ts
@@ -1,0 +1,115 @@
+
+async function waitFunction(waitMilliseconds: number): Promise<boolean> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(true);
+    }, waitMilliseconds);
+  });
+}
+
+async function timeout(timeoutMilliseconds: number) {
+  return new Promise((_, reject) => {
+    setTimeout(reject, timeoutMilliseconds);
+  });
+}
+
+async function raceToWait(
+    waitMilliseconds: number, timeoutMilliseconds: number) {
+  await Promise.race([
+    waitFunction(waitMilliseconds), timeout(timeoutMilliseconds)]);
+}
+
+async function test1() {
+  // resolves because the wait < than the timeout (100 < 1000).
+  let startWaitResolve = Date.now();
+  try {
+    await raceToWait(100, 1000);
+    console.log('Expected resolve');
+  } catch (e) {
+    console.log('Error: should not get here.');
+  }
+  let endWaitResolve = Date.now();
+  console.log(
+    `Resolve timeout ${endWaitResolve - startWaitResolve} milliseconds`);
+
+  // rejects because the wait > than the timeout (1000, 100);
+  let startWaitReject = Date.now();
+  try {
+    await raceToWait(1000, 100);
+  } catch (e) {
+    console.log('Expected reject');
+  }
+  let endWaitReject = Date.now();
+  console.log(
+    `Reject timeout ${endWaitReject - startWaitReject} milliseconds`);
+}
+
+// test1();
+
+
+/**
+ * Resolves when the condition resolves to truthy. Rejects when the timeout
+ * completes first.
+ * @param condition 
+ * @param timeoutMilliseconds 
+ */
+async function wait(
+    condition: Promise<boolean>|boolean,
+    timeoutMilliseconds: number) {
+  let resolveCondition = new Promise(async (resolve, reject) => {
+    let conditionMet = false;
+    let remainderTime = timeoutMilliseconds;
+    while(!conditionMet) {
+      let start = Date.now();
+      conditionMet = await condition;
+      if (conditionMet) {
+        resolve();
+        return;
+      }
+      let end = Date.now();
+      let duration = end - start;
+      remainderTime = remainderTime - 100 - duration;
+      let remainder = 100 - duration;
+      if (remainder > 0) {
+        console.log(`We did not return and slept for ${remainder}`);
+        await new Promise(resolve2 => {
+          setTimeout(resolve2, remainder);
+        });
+      }
+      if (remainderTime < 0) {
+        reject();
+        return;
+      }
+    }
+  });
+  let rejectTimeout = new Promise((_, reject) => {
+    setTimeout(reject, timeoutMilliseconds);
+  });
+  await Promise.race([resolveCondition, rejectTimeout]);
+}
+
+async function test2() {
+  // let startWaitResolve = Date.now();
+  // try {
+  //   await wait(waitFunction(100), 1000);
+  //   console.log('Expected resolve');
+  // } catch (e) {
+  //   console.log('Error: should not get here.');
+  // }
+  // let endWaitResolve   = Date.now();
+  // console.log(
+  //   `Resolve timeout ${endWaitResolve - startWaitResolve} milliseconds`);
+
+  // rejects because the wait > than the timeout (1000, 100);
+  let startWaitReject = Date.now();
+  try {
+    await wait(false, 1000);
+  } catch (e) {
+    console.log('Expected reject');
+  }
+  let endWaitReject = Date.now();
+  console.log(
+    `Reject timeout ${endWaitReject - startWaitReject} milliseconds`);
+}
+
+test2();

--- a/wait-to-resolve-reject/package-lock.json
+++ b/wait-to-resolve-reject/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "race-to-wait",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "14.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    }
+  }
+}

--- a/wait-to-resolve-reject/package.json
+++ b/wait-to-resolve-reject/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wait-to-resolve-reject",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "tsc && node dist"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^14.11.8",
+    "typescript": "^4.0.3"
+  }
+}

--- a/wait-to-resolve-reject/tsconfig.json
+++ b/wait-to-resolve-reject/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": [ "es2017" ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "outDir": "dist",
+    "pretty": true,
+    "removeComments": false,
+    "sourceMap": true,
+    "target": "es2017",
+  },
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+}


### PR DESCRIPTION
- Proof of concept for browser.wait method to either resolve or reject.
Attempted to model this function similar to
https://github.com/SeleniumHQ/selenium/blob/63d986984f9c5d3bd78f41ef16ff7664cac8763b/javascript/node/selenium-webdriver/lib/webdriver.js#L781
however the selenium-webdriver version must always await the condition
to resolve. If the condition does not resolve, then this function could
hang the entire test sutie.